### PR TITLE
Fix chapter-appears-as-book-title bug.

### DIFF
--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -245,10 +245,9 @@ class BiblePreprocessor(Preprocessor):
                     chapters = self.rc.chapters(project.identifier)
                     if len(chapters):
                         #          Piece the USFM file together
-                        title_file = os.path.join(project_path, chapters[0], 'title.txt')
+                        title_file = os.path.join(project_path, 'front', 'title.txt')
                         if os.path.isfile(title_file):
-                            title = read_file(title_file)
-                            title = re.sub(r' \d+$', '', title).strip()
+                            title = read_file(title_file).strip()
                         else:
                             title = project.title
                         if not title and os.path.isfile(os.path.join(project_path, 'title.txt')):
@@ -259,6 +258,7 @@ class BiblePreprocessor(Preprocessor):
 \\h {2}
 \\toc1 {2}
 \\toc2 {2}
+\\toc3 {2}
 \\mt {2}
 """.format(project.identifier.upper(), self.rc.resource.title, title)
                         for chapter in chapters:


### PR DESCRIPTION
Only load book title.txt from front matter folder.

Based on commit https://github.com/unfoldingWord-dev/door43-job-handler/pull/67/commits/7f6d73f36a375773024e1be9e1ec5e00c6db46a3 in pull request https://github.com/unfoldingWord-dev/door43-job-handler/pull/67

### Broken production example:    
http://read.bibletranslationtools.org/u/jdwood/nkv_mat_text_reg/53747325fa/
(Image in comment below.)

### Same example (forked scripture repo, but unmodified) with this change, showing fix:    
http://read-dev.bibletranslationtools.org/u/russell/nkv_mat_text_reg/7dc1ab681c/
(Image in comment below.)

