### PR TITLE
Move MD linter to Node 10

### DIFF
--- a/functions/markdown_linster/function.json
+++ b/functions/markdown_linster/function.json
@@ -1,6 +1,6 @@
 {
   "description": "Markdown linter in node.js. This is called in checkers/markdown_checker.py by lambda invoke",
-  "runtime": "nodejs6.10",
+  "runtime": "nodejs10.x",
   "hooks": {
     "build": "npm install",
     "clean": "rm -rf node_modules"


### PR DESCRIPTION
Upgrade to Nodejs v10. 
Lambda stopped supporting Node 6, so deploys fail.