### PR TITLE
Improve debug and exception logging

### DIFF
--- a/libraries/lambda_handlers/door43_deploy_handler.py
+++ b/libraries/lambda_handlers/door43_deploy_handler.py
@@ -55,6 +55,6 @@ class Door43DeployHandler(Handler):
                 # this is triggered manually through AWS Lambda console to update all projects
                 deployer.redeploy_all_projects(deploy_function)
 
-        except Exception as e:
-            App.logger.debug("Project Deployer Error: " + str(e))
+        except Exception:
+            App.logger.exception("Project Deployer Error")
             deployer.close()


### PR DESCRIPTION
- Use `Logger.exception` so stack traces are included in CloudWatch logs
- If a linter isn't found, log the available linters for debugging convenience