### PR TITLE
Use HTTP redirection from index.html to main content

### DIFF
--- a/libraries/aws_tools/s3_handler.py
+++ b/libraries/aws_tools/s3_handler.py
@@ -159,7 +159,11 @@ class S3Handler(object):
         return self.resource.Object(bucket_name=self.bucket_name, key=key)
 
     def redirect(self, key, location):
-        self.bucket.put_object(Key=key, WebsiteRedirectLocation=location, CacheControl='max-age=0')
+        return self.bucket.put_object(
+            Key=key,
+            WebsiteRedirectLocation=location,
+            CacheControl='max-age=0'
+        )
 
     def get_file_contents(self, key, catch_exception=True):
         if catch_exception:


### PR DESCRIPTION
Use 302 HTTP redirection to load the main page in Live Reader, instead of copying its contents into index.html.

This change was part of a false start to fixing a linking error, but it turned out to be a nice option.

It's certainly just an option though.
### Advantages:
1. Jumping to anchors from the index previously required another page load, but now that page is already the active one, so the browser only needs to scroll the target into view.
2. There are no longer two identical URLs with the main page content.

### Disadvantage:
1. When visiting the manual's top level, the URL will look uglier. Instead of ending with `/index.html` or `/`, it will end with the main page's filename (`/01-wycliffe%20associates%20translation.html` in the case of tM).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/tx-manager/7)
<!-- Reviewable:end -->
