### PR TITLE
Default to current AWS region

### DIFF
--- a/libraries/aws_tools/dynamodb_handler.py
+++ b/libraries/aws_tools/dynamodb_handler.py
@@ -7,7 +7,7 @@ from boto3.dynamodb.conditions import Attr
 
 class DynamoDBHandler(object):
 
-    def __init__(self, table_name, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):
+    def __init__(self, table_name, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name=None):
         self.table_name = table_name
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key

--- a/libraries/aws_tools/lambda_handler.py
+++ b/libraries/aws_tools/lambda_handler.py
@@ -4,7 +4,7 @@ import boto3
 
 
 class LambdaHandler(object):
-    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name=None):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_region_name = aws_region_name

--- a/libraries/aws_tools/s3_handler.py
+++ b/libraries/aws_tools/s3_handler.py
@@ -9,7 +9,7 @@ from libraries.general_tools.file_utils import get_mime_type
 
 class S3Handler(object):
     def __init__(self, bucket_name=None, aws_access_key_id=None, aws_secret_access_key=None,
-                 aws_region_name='us-west-2'):
+                 aws_region_name=None):
         self.bucket_name = bucket_name
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key


### PR DESCRIPTION
When calling another Lambda function, don't force it to `us-west-2` (which we don't use)